### PR TITLE
Fix LUT cleanup and CBC padding issues

### DIFF
--- a/aes.c
+++ b/aes.c
@@ -454,7 +454,8 @@ void QuitLUTMode(void) {
         }
         free(te);
         te = NULL;
-    } else if (td != NULL) {
+    }
+    if (td != NULL) {
         for (int i = 0; i < 4; i++) {
             for (int j = 0; j < 256; j++) {
                 if (td[i][j] != NULL)
@@ -463,7 +464,7 @@ void QuitLUTMode(void) {
             free(td[i]);
         }
         free(td);
-        te = NULL;
+        td = NULL;
     }
     if (lut_decry_roundkeylist != NULL) {
         for (int i = 0; i < numofwords; i++)

--- a/opmode.c
+++ b/opmode.c
@@ -235,8 +235,17 @@ void DecryptCBC(char *infilename, char *outfilename) {
         DecryptSBox(cipherblock, plainblock);
         for (int i = 0; i < BLOCK_SIZE; i++)
             plainblock[i] ^= temp[i];
-        PKCS7UnPadding(plainblock);
-        fwrite(plainblock, sizeof(uint8_t), BLOCK_SIZE, wfp);
+        int8_t padsize = PKCS7UnPadding(plainblock);
+        if (padsize != -1)
+            fwrite(plainblock, sizeof(uint8_t), BLOCK_SIZE - padsize, wfp);
+        else {
+            fclose(rfp);
+            fclose(wfp);
+            free(plainblock);
+            free(cipherblock);
+            free(temp);
+            return;
+        }
     } else if (ciphermode == LUT) {
         for (int i = 0; i < repeat - 1; i++) {
             fread(cipherblock, sizeof(uint8_t), BLOCK_SIZE, rfp);


### PR DESCRIPTION
## Summary
- free both lookup tables in `QuitLUTMode`
- correctly handle padding during CBC decryption

## Testing
- `cmake .. && make -j$(nproc)`

